### PR TITLE
Fix compilation errors in `tools/`

### DIFF
--- a/tools/src/comp.cpp
+++ b/tools/src/comp.cpp
@@ -54,39 +54,39 @@ int main(int argc, char** argv) {
 	if (matrix_A_info.matrix_type != matrix_B_info.matrix_type) {std::printf("The matrix types are mismatch\n"); return 1;}
 	if (matrix_A_info.m != matrix_B_info.m || matrix_A_info.n != matrix_B_info.n) {std::printf("The matrix sizes are mismatch\n"); return 1;}
 
-	if (matrix_A_info.data_type == mtk::matfile::fp32) {
+	if (matrix_A_info.data_type == mtk::matfile::data_t::fp32) {
 		using T = float;
-		if (matrix_B_info.data_type == mtk::matfile::fp32) {
+		if (matrix_B_info.data_type == mtk::matfile::data_t::fp32) {
 			using S = float;
 			comp<T, S>(matrix_A_path, matrix_B_path, matrix_A_info.m, matrix_A_info.n);
-		} else if (matrix_B_info.data_type == mtk::matfile::fp64) {
+		} else if (matrix_B_info.data_type == mtk::matfile::data_t::fp64) {
 			using S = double;
 			comp<T, S>(matrix_A_path, matrix_B_path, matrix_A_info.m, matrix_A_info.n);
-		} else if (matrix_B_info.data_type == mtk::matfile::fp128) {
+		} else if (matrix_B_info.data_type == mtk::matfile::data_t::fp128) {
 			using S = long double;
 			comp<T, S>(matrix_A_path, matrix_B_path, matrix_A_info.m, matrix_A_info.n);
 		}
-	}else if (matrix_A_info.data_type == mtk::matfile::fp64) {
+	}else if (matrix_A_info.data_type == mtk::matfile::data_t::fp64) {
 		using T = double;
-		if (matrix_B_info.data_type == mtk::matfile::fp32) {
+		if (matrix_B_info.data_type == mtk::matfile::data_t::fp32) {
 			using S = float;
 			comp<T, S>(matrix_A_path, matrix_B_path, matrix_A_info.m, matrix_A_info.n);
-		} else if (matrix_B_info.data_type == mtk::matfile::fp64) {
+		} else if (matrix_B_info.data_type == mtk::matfile::data_t::fp64) {
 			using S = double;
 			comp<T, S>(matrix_A_path, matrix_B_path, matrix_A_info.m, matrix_A_info.n);
-		} else if (matrix_B_info.data_type == mtk::matfile::fp128) {
+		} else if (matrix_B_info.data_type == mtk::matfile::data_t::fp128) {
 			using S = long double;
 			comp<T, S>(matrix_A_path, matrix_B_path, matrix_A_info.m, matrix_A_info.n);
 		}
-	}else if (matrix_A_info.data_type == mtk::matfile::fp128) {
+	}else if (matrix_A_info.data_type == mtk::matfile::data_t::fp128) {
 		using T = long double;
-		if (matrix_B_info.data_type == mtk::matfile::fp32) {
+		if (matrix_B_info.data_type == mtk::matfile::data_t::fp32) {
 			using S = float;
 			comp<T, S>(matrix_A_path, matrix_B_path, matrix_A_info.m, matrix_A_info.n);
-		} else if (matrix_B_info.data_type == mtk::matfile::fp64) {
+		} else if (matrix_B_info.data_type == mtk::matfile::data_t::fp64) {
 			using S = double;
 			comp<T, S>(matrix_A_path, matrix_B_path, matrix_A_info.m, matrix_A_info.n);
-		} else if (matrix_B_info.data_type == mtk::matfile::fp128) {
+		} else if (matrix_B_info.data_type == mtk::matfile::data_t::fp128) {
 			using S = long double;
 			comp<T, S>(matrix_A_path, matrix_B_path, matrix_A_info.m, matrix_A_info.n);
 		}

--- a/tools/src/info.cpp
+++ b/tools/src/info.cpp
@@ -8,7 +8,7 @@ void print_info(
 	const std::string matfile_path
 	) {
 	std::size_t m, n;
-	mtk::matfile::load_size(m, n, matfile_path);
+	mtk::matfile::load_matrix_size(m, n, matfile_path);
 
 	std::printf("# size  : %lu x %lu\n", m, n);
 	std::printf("# dtype : %s\n", mtk::matfile::detail::get_type_name_str<T>().c_str());
@@ -34,9 +34,9 @@ int main(
 		std::printf("## ---- [%d] path : %s ----\n", i, matfile_path.c_str());
 
 		const auto dtype = mtk::matfile::load_dtype(matfile_path);
-		if (dtype == mtk::matfile::fp32) {
+		if (dtype == mtk::matfile::data_t::fp32) {
 			print_info<float >(matfile_path);
-		} else if (dtype == mtk::matfile::fp64) {
+		} else if (dtype == mtk::matfile::data_t::fp64) {
 			print_info<double>(matfile_path);
 		}
 	}

--- a/tools/src/print.cpp
+++ b/tools/src/print.cpp
@@ -12,7 +12,7 @@ void print_matfile(
 	const bool print_hex_flag
 	) {
 	std::size_t m, n;
-	mtk::matfile::load_size(m, n, matfile_path);
+	mtk::matfile::load_matrix_size(m, n, matfile_path);
 	std::unique_ptr<T> mat_uptr(new T[m * n]);
 
 	mtk::matfile::load_dense(mat_uptr.get(), m, matfile_path);
@@ -52,11 +52,11 @@ int main(int argc, char** argv) {
 		const std::string matfile_path = argv[path_index];
 		const auto matfile_header = mtk::matfile::load_header(matfile_path);
 
-		if (matfile_header.data_type == mtk::matfile::fp32) {
+		if (matfile_header.data_type == mtk::matfile::data_t::fp32) {
 			print_matfile<float>(matfile_path, print_hex_flag);
-		} else if (matfile_header.data_type == mtk::matfile::fp64) {
+		} else if (matfile_header.data_type == mtk::matfile::data_t::fp64) {
 			print_matfile<double>(matfile_path, print_hex_flag);
-		} else if (matfile_header.data_type == mtk::matfile::fp128) {
+		} else if (matfile_header.data_type == mtk::matfile::data_t::fp128) {
 			print_matfile<long double>(matfile_path, print_hex_flag);
 		}
 	}


### PR DESCRIPTION
The targets in `tools/` were not compiling for me.

I think that the main library had moved on, but these tools had somehow not been updated.