### PR TITLE
Fix inconsistent macro naming for old data format

### DIFF
--- a/include/matfile/matfile.hpp
+++ b/include/matfile/matfile.hpp
@@ -251,7 +251,7 @@ void save_dense(
 	file_header.m = m;
 	file_header.n = n;
 	file_header.matrix_type = matrix_t::dense;
-#ifndef OLD_VERSION
+#ifndef MATFILE_USE_OLD_FORMAT
 	file_header.version = detail::get_version_uint32(0, 7);
 #endif
 


### PR DESCRIPTION
I tried to compile the library after defining `MATFILE_USE_OLD_FORMAT` and got an error, because [here](https://github.com/enp1s0/matfile/blob/2955fd26226025472c18202164354665a0661c7f/include/matfile/matfile.hpp#L255) the function `mtk::matfile::save_dense` tries to access the `version` field of `file_header`, which is not defined.

This one-liner should fix the issue.